### PR TITLE
Fixes Issue #37, #36, #38

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,8 @@
     "python.testing.cwd": "${workspaceFolder}/test",
     "python.testing.unittestEnabled": false,
     "python.testing.nosetestsEnabled": false,
-    "python.testing.pytestEnabled": true,
+    "python.testing.pytestEnabled": false,
+    "python.testing.autoTestDiscoverOnSaveEnabled": false,
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,11 @@ exclude_lines =
 
 [nanaimo]
 test_cfg = 1
+log_level = VERBOSE_DEBUG
+
+[nanaimo:bk]
+# This is required so give it a value so our unit tests will pass.
+port = None
 
 [nanaimo:test]
 cfg = 2

--- a/src/nanaimo/builtin/gtest_over_jlink.py
+++ b/src/nanaimo/builtin/gtest_over_jlink.py
@@ -42,6 +42,7 @@ class Fixture(nanaimo.Fixture):
     gtest tests pass else returns non-zero.
     """
     fixture_name = 'gtest_over_jlink'
+    argument_prefix = 'gtest'
 
     @classmethod
     def on_visit_test_arguments(cls, arguments: nanaimo.Arguments) -> None:

--- a/src/nanaimo/connections/uart.py
+++ b/src/nanaimo/connections/uart.py
@@ -163,7 +163,7 @@ class ConcurrentUart(AbstractAsyncSerial):
                 self._read_buffer.put_nowait(timestamped_line)
                 self._logger_rx.debug(re.sub('\\r', '<cr>', timestamped_line))
             except queue.Full:
-                self._logger_rx.warn("read buffer overflow.")
+                self._logger_rx.warning("read buffer overflow.")
                 self._rx_buffer_overflows += 1
 
     def _buffer_output(self) -> None:

--- a/src/nanaimo/instruments/bkprecision/__init__.py
+++ b/src/nanaimo/instruments/bkprecision/__init__.py
@@ -33,6 +33,7 @@ class Series1900BUart(nanaimo.Fixture):
     """
 
     fixture_name = 'bkprecision'
+    argument_prefix = 'bk'
 
     DefaultCommandTimeoutSeconds = 6.0
 
@@ -98,6 +99,7 @@ class Series1900BUart(nanaimo.Fixture):
     def on_visit_test_arguments(cls, arguments: nanaimo.Arguments) -> None:
         arguments.add_argument('--bk-port',
                                enable_default_from_environ=True,
+                               required=True,
                                help='The port the BK Precision power supply is connected to.')
         arguments.add_argument('--bk-command', '--BC',
                                help='command', default='?')
@@ -199,7 +201,7 @@ class Series1900BUart(nanaimo.Fixture):
                 setattr(artifacts, 'display_text', '{},{},{}'.format(
                     display[0], display[1], self.mode_to_text(int(display[1]))))
         else:
-            self.logger.warn('command {} is not a valid Series1900BUart command.'.format(args.bk_command))
+            self.logger.warning('command {} is not a valid Series1900BUart command.'.format(args.bk_command))
 
         return artifacts
 

--- a/src/nanaimo/pytest_plugin.py
+++ b/src/nanaimo/pytest_plugin.py
@@ -112,10 +112,12 @@ def create_pytest_fixture(pytest_request: typing.Any, fixture_type: typing.Type[
 
 def pytest_addoption(parser) -> None:  # type: ignore
     manager = _get_default_fixture_manager()
-    nanaimo_defaults = nanaimo.config.ArgumentDefaults()
+    nanaimo_defaults = ArgumentDefaults.createDefaultsWithEarlyRcConfig()
     for fixture_type in manager.fixture_types():
         group = parser.getgroup(fixture_type.get_canonical_name())
-        fixture_type.on_visit_test_arguments(nanaimo.Arguments(group, nanaimo_defaults))
+        fixture_type.on_visit_test_arguments(nanaimo.Arguments(group,
+                                                               nanaimo_defaults,
+                                                               fixture_type.get_argument_prefix()))
 
 
 @pytest.fixture

--- a/src/nanaimo/version.py
+++ b/src/nanaimo/version.py
@@ -18,6 +18,6 @@
 #  nanaimo                                   (@&&&&####@@*
 #
 
-__version__ = '0.0.19'
+__version__ = '0.0.20'
 
 __license__ = 'MIT'

--- a/test/test_artifacts.py
+++ b/test/test_artifacts.py
@@ -2,9 +2,6 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # This software is distributed under the terms of the MIT License.
 #
-
-import pytest
-
 import nanaimo
 
 
@@ -18,11 +15,11 @@ def test_create_artifacts() -> None:
 
 def test_missing_artifact() -> None:
     """
-    Verified that KeyError is raised if an undefined artifact is accessed.
+    Verified that KeyError is not raised if an undefined artifact is accessed.
     """
     subject = nanaimo.Artifacts()
-    with pytest.raises(KeyError):
-        subject.not_an_artifact
+    assert subject.not_an_artifact is None
+    assert 'not_an_artifact' not in subject
 
 
 def test_result_code() -> None:

--- a/test/test_nait.py
+++ b/test/test_nait.py
@@ -28,5 +28,5 @@ def test_nanaimo_bar(run_nait) -> None:  # type: ignore
     """
     Eat your dessert!
     """
-    result = run_nait(['-vv', 'nanaimo_bar']).stdout.decode('utf-8')
+    result = run_nait(['--log-level', 'VERBOSE_DEBUG', 'nanaimo_bar']).stdout.decode('utf-8')
     print(result)

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -6,8 +6,6 @@
 import configparser
 import pathlib
 
-import pytest
-
 import nanaimo
 from nanaimo.config import ArgumentDefaults
 
@@ -28,8 +26,7 @@ def test_create_single_parent() -> None:
     setattr(parent, 'foo', 1)
     child = nanaimo.Namespace(parent)
     assert 1 == child.foo
-    with pytest.raises(KeyError):
-        child.bar
+    assert 'bar' not in child
 
 
 def test_create_grandparent() -> None:
@@ -75,8 +72,7 @@ def test_overrides(test_config: pathlib.Path) -> None:
     setattr(fake_args, 'rcfile', str(test_config))
     defaults = ArgumentDefaults()
     subject = nanaimo.Namespace(None, defaults)
-    with pytest.raises(KeyError):
-        assert subject.test_attr_yup == 'yup'
+    assert 'test_attr_yup' not in subject
 
     defaults.set_args(fake_args)
     setattr(subject, 'test_attr_nope', 'yup')

--- a/test/test_nanaimo.py
+++ b/test/test_nanaimo.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import pathlib
 import typing
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -223,3 +223,21 @@ def test_enable_default_from_environ(nanaimo_defaults: nanaimo.config.ArgumentDe
 
     with pytest.raises(RuntimeError):
         a.add_argument('--yep', enable_default_from_environ=True)
+
+
+@pytest.mark.parametrize('required_prefix,test_positional_args,test_expected_args',
+                         [  # type: ignore
+                             ('tt', ['--foo-bar'], ['--tt-foo-bar']),
+                             ('z', ['-f', '--foo-bar'], ['-f', '--z-foo-bar']),
+                             ('pre', ['--foo-bar', '-x'], ['--pre-foo-bar', '-x']),
+                             ('a', ['-foo-bar', '-x'], ['-foo-bar', '-x'])
+                         ])
+def test_require_prefix(required_prefix, test_positional_args, test_expected_args) -> None:
+    parser = MagicMock(spec=argparse.ArgumentParser)
+    parser.add_argument = MagicMock()
+
+    a = nanaimo.Arguments(parser, required_prefix=required_prefix)
+
+    a.add_argument(*test_positional_args)
+
+    parser.add_argument.assert_called_once_with(*test_expected_args)


### PR DESCRIPTION
A bit of a refactor here to deal with emergent complexity. This change
introduces the following:

1. special treatment of the --rcfile argument to allow argument defaults
to be populated from cfg files.
2. None values are removed from the argparse Namespace but the Nanaimo
namespace treats all undefined attributes as None values.
3. Fixtures now have prefixes enforced to make the CLI consistent with
the configuration files.
4. --log-level replaces --verbose to allow logging to be configured in a
file.