### PR TITLE
Issue #31, #40, #41

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,8 +68,9 @@ These take the form of docstrings with a structure like thus::
     .. code-block:: python
 
         # Use bar method to transform baz
-        bar('baz')
-        >>> 'braz'
+
+    >>> bar('baz')  # noqa : F821
+    'braz'
 
 The invisible code block is executed but not displayed in the generated documentation and,
 conversely, ``code-block`` is both rendered using proper syntax formatting in the documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,11 +47,13 @@ pytest11 =
     pytest_nanaimo = nanaimo.pytest_plugin
     pytest_nanaimo_bar = nanaimo.builtin.nanaimo_bar
     pytest_gtest_over_jlink = nanaimo.builtin.gtest_over_jlink
+    pytest_serial_log_watch = nanaimo.builtin.serial_log_watch
 nanaimo = 
     nanaimo_builtin_bar = nanaimo.builtin.nanaimo_bar
     nanaimo_builtin_saleae = nanaimo.instruments.saleae
     nanaimo_builtin_bkprecision = nanaimo.instruments.bkprecision
     nanaimo_builtin_gtest = nanaimo.builtin.gtest_over_jlink
+    nanaimo_builtin_serial_log_watch = nanaimo.builtin.serial_log_watch
 console_scripts =
     nait = nanaimo.cli:main
 
@@ -119,9 +121,8 @@ exclude_lines =
 test_cfg = 1
 log_level = VERBOSE_DEBUG
 
-[nanaimo:bk]
-# This is required so give it a value so our unit tests will pass.
-port = None
-
 [nanaimo:test]
 cfg = 2
+
+[nanaimo:bk]
+port = dummy/port/from/config.cfg

--- a/src/nanaimo/builtin/nanaimo_bar.py
+++ b/src/nanaimo/builtin/nanaimo_bar.py
@@ -32,6 +32,7 @@ class Fixture(nanaimo.Fixture):
     """
 
     fixture_name = 'nanaimo_bar'
+    argument_prefix = 'nb'
 
     @classmethod
     def on_visit_test_arguments(cls, arguments: nanaimo.Arguments) -> None:

--- a/src/nanaimo/builtin/serial_log_watch.py
+++ b/src/nanaimo/builtin/serial_log_watch.py
@@ -1,0 +1,118 @@
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This software is distributed under the terms of the MIT License.
+#
+#                                       (@@@@%%%%%%%%%&@@&.
+#                              /%&&%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%&@@(
+#                              *@&%%%%%%%%%&&%%%%%%%%%%%%%%%%%%&&&%%%%%%%
+#                               @   @@@(@@@@%%%%%%%%%%%%%%%%&@@&* @@@   .
+#                               ,   .        .  .@@@&                   /
+#                                .       .                              *
+#                               @@              .                       @
+#                              @&&&&&&@. .    .                     *@%&@
+#                              &&&&&&&&&&&&&&&&@@        *@@############@
+#                     *&/ @@ #&&&&&&&&&&&&&&&&&&&&@  ###################*
+#                              @&&&&&&&&&&&&&&&&&&##################@
+#                                 %@&&&&&&&&&&&&&&################@
+#                                        @&&&&&&&&&&%#######&@%
+#  nanaimo                                   (@&&&&####@@*
+#
+import asyncio
+import re
+import typing
+
+import pytest
+
+import nanaimo
+import nanaimo.connections
+import nanaimo.connections.uart
+import nanaimo.pytest_plugin
+
+
+class Fixture(nanaimo.Fixture):
+    """
+    Gathers a log over a serial connection until a given pattern is matched.
+    """
+
+    fixture_name = 'serial_log_watch'
+    argument_prefix = 'lw'
+
+    def __init__(self,
+                 manager: nanaimo.FixtureManager,
+                 args: nanaimo.Namespace,
+                 **kwargs: typing.Any) -> None:
+        super().__init__(manager, args, **kwargs)
+        if 'uart_factory' in kwargs:
+            self._uart_factory = typing.cast(typing.Callable[[str, int], nanaimo.connections.uart.ConcurrentUart],
+                                             kwargs['uart_factory'])
+        else:
+            self._uart_factory = nanaimo.connections.uart.ConcurrentUart.new_default
+
+    @classmethod
+    def on_visit_test_arguments(cls, arguments: nanaimo.Arguments) -> None:
+        nanaimo.connections.uart.ConcurrentUart.on_visit_test_arguments(arguments)
+        arguments.add_argument('--lw-pattern',
+                               default='.*',
+                               enable_default_from_environ=True,
+                               help='A python regular expression to search for')
+        arguments.add_argument('--lw-disruption', default='\r\n')
+        arguments.add_argument('--lw-disturb-rate', type=float)
+
+    async def on_gather(self, args: nanaimo.Namespace) -> nanaimo.Artifacts:
+        """
+        Watch the logs until the pattern matches.
+        """
+        with self._uart_factory(args.lw_port, args.lw_port_speed) as monitor:
+            disturb_rate = args.lw_disturb_rate
+            if disturb_rate is not None and float(disturb_rate) > 0:
+                while True:
+                    done, pending = await asyncio.wait([asyncio.ensure_future(self._matcher(args, monitor)),
+                                                        asyncio.ensure_future(self._agitator(args, monitor))])
+                    if len(done) == 2:
+                        done0 = done.pop().result()
+                        done1 = done.pop().result()
+                        artifacts = nanaimo.Artifacts.combine(done0, done1)
+                        break
+            else:
+                artifacts = await self._matcher(args, monitor)
+
+        self._logger.info('Found match : %s', artifacts.matched_line)
+        return artifacts
+
+    # +-----------------------------------------------------------------------+
+    # | PRIVATE
+    # +-----------------------------------------------------------------------+
+
+    async def _matcher(self, args: nanaimo.Namespace,
+                       monitor: nanaimo.connections.uart.ConcurrentUart) -> nanaimo.Artifacts:
+        artifacts = nanaimo.Artifacts()
+        pattern = re.compile(args.lw_pattern)
+
+        self._logger.debug('Starting to look for pattern : %s', str(pattern))
+        while True:
+            result = await monitor.get_line()
+            match = pattern.search(result)
+            if match:
+                setattr(artifacts, 'match', match)
+                setattr(artifacts, 'matched_line', result)
+                break
+
+        return artifacts
+
+    async def _agitator(self, args: nanaimo.Namespace,
+                        monitor: nanaimo.connections.uart.ConcurrentUart) -> nanaimo.Artifacts:
+        artifacts = nanaimo.Artifacts()
+        await asyncio.sleep(args.lw_disturb_rate)
+        self._logger.debug('About to disturb the uart...')
+        await monitor.put_line(args.lw_disruption)
+        return artifacts
+
+
+@nanaimo.PluggyFixtureManager.type_factory
+def get_fixture_type() -> typing.Type['nanaimo.Fixture']:
+    return Fixture
+
+
+@pytest.fixture
+def serial_log_watch(request: typing.Any) -> nanaimo.Fixture:
+    return nanaimo.pytest_plugin.create_pytest_fixture(request, Fixture)

--- a/src/nanaimo/connections/__init__.py
+++ b/src/nanaimo/connections/__init__.py
@@ -53,7 +53,7 @@ class AbstractSerial:
         arguments.add_argument('--port',
                                help='The port to monitor.')
 
-        arguments.add_argument('--port-speed', '-B', help='the speed of the port (e.g. baud rate for serial ports).')
+        arguments.add_argument('--port-speed', help='the speed of the port (e.g. baud rate for serial ports).')
 
 
 class AbstractAsyncSerial(AbstractSerial):

--- a/src/nanaimo/instruments/bkprecision/__init__.py
+++ b/src/nanaimo/instruments/bkprecision/__init__.py
@@ -89,11 +89,14 @@ class Series1900BUart(nanaimo.Fixture):
     def __init__(self,
                  manager: 'nanaimo.FixtureManager',
                  args: nanaimo.Namespace,
-                 loop: typing.Optional[asyncio.AbstractEventLoop] = None,
-                 uart_factory: typing.Optional[UartFactoryType] = None):
-        super().__init__(manager, args, loop)
+                 **kwargs: typing.Any):
+        super().__init__(manager, args, **kwargs)
         self._debug = False
-        self._uart_factory = (uart_factory if uart_factory is not None else self.default_serial_port)
+        if 'uart_factory' in kwargs:
+            uart_factory = typing.cast(typing.Optional['Series1900BUart.UartFactoryType'], kwargs['uart_factory'])
+            self._uart_factory = (uart_factory if uart_factory is not None else self.default_serial_port)
+        else:
+            self._uart_factory = self.default_serial_port
 
     @classmethod
     def on_visit_test_arguments(cls, arguments: nanaimo.Arguments) -> None:
@@ -139,7 +142,7 @@ class Series1900BUart(nanaimo.Fixture):
             +---------+----------------------------------+--------------------------------------------------+
         """
 
-        with self._uart_factory(str(args.bk_port)) as bk_uart:
+        with self._uart_factory(args.bk_port) as bk_uart:
             artifacts = await self._do_command_from_args(bk_uart, args)
 
         return artifacts

--- a/src/nanaimo/lib.rst
+++ b/src/nanaimo/lib.rst
@@ -33,17 +33,24 @@ nanaimo (library)
    :members:
 
 ***************************************
-:mod:`nanaimo.builtin.gtest_over_jlink`
-***************************************
-
-.. automodule:: nanaimo.builtin.gtest_over_jlink
-   :members:
-
-***************************************
 :mod:`nanaimo.builtin.nanaimo_bar`
 ***************************************
 
 .. automodule:: nanaimo.builtin.nanaimo_bar
+   :members:
+
+***************************************
+:mod:`nanaimo.builtin.serial_log_watch`
+***************************************
+
+.. automodule:: nanaimo.builtin.serial_log_watch
+   :members:
+
+***************************************
+:mod:`nanaimo.builtin.gtest_over_jlink`
+***************************************
+
+.. automodule:: nanaimo.builtin.gtest_over_jlink
    :members:
 
 *************************************

--- a/src/nanaimo/version.py
+++ b/src/nanaimo/version.py
@@ -18,6 +18,6 @@
 #  nanaimo                                   (@&&&&####@@*
 #
 
-__version__ = '0.0.21'
+__version__ = '0.0.22'
 
 __license__ = 'MIT'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # This software is distributed under the terms of the MIT License.
 #
+import asyncio
 import os
 import pathlib
 import subprocess
@@ -10,7 +11,9 @@ import typing
 import pytest
 
 import fixtures
+import fixtures.simulators
 import nanaimo
+import nanaimo.pytest_plugin
 from nanaimo.config import ArgumentDefaults
 
 
@@ -75,3 +78,30 @@ def s32K144_jlink_script(request):  # type: ignore
 @pytest.fixture
 def s32K144_jlink_scripts(request):  # type: ignore
     return pathlib.Path(fixtures.__file__).parent.glob('*.jlink')
+
+
+@pytest.fixture
+def serial_simulator_type(request):  # type: ignore
+    return fixtures.simulators.Serial
+
+
+class GatherTimeoutFixture(nanaimo.Fixture):
+
+    @classmethod
+    def on_visit_test_arguments(cls, arguments: nanaimo.Arguments) -> None:
+        pass
+
+    async def on_gather(self, args: nanaimo.Namespace) -> nanaimo.Artifacts:
+        """
+        Sleep forever
+        """
+        while True:
+            await asyncio.sleep(1)
+
+
+@pytest.fixture
+def gather_timeout_fixture(request: typing.Any) -> nanaimo.Fixture:
+    args = nanaimo.Namespace(request.config.option,
+                             ArgumentDefaults(request.config.option),
+                             allow_none_values=False)
+    return GatherTimeoutFixture(nanaimo.FixtureManager(), args)

--- a/test/fixtures/__init__.py
+++ b/test/fixtures/__init__.py
@@ -7,7 +7,6 @@ Contains data files used in tests. Use conftest.py for fixtures.
 """
 import nanaimo
 import typing
-import asyncio
 import pathlib
 
 FAKE_TEST_SUCCESS = '''[==========] Running 140 tests from 7 test suites.
@@ -324,8 +323,8 @@ class DummyFixture(nanaimo.Fixture):
     def __init__(self,
                  manager: nanaimo.FixtureManager,
                  args: nanaimo.Namespace = nanaimo.Namespace(),
-                 loop: typing.Optional[asyncio.AbstractEventLoop] = None):
-        super().__init__(manager, args, loop)
+                 **kwargs: typing.Any):
+        super().__init__(manager, args, **kwargs)
 
     @classmethod
     def on_visit_test_arguments(cls, arguments: nanaimo.Arguments) -> None:

--- a/test/test_fixture.py
+++ b/test/test_fixture.py
@@ -1,0 +1,143 @@
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This software is distributed under the terms of the MIT License.
+#
+import asyncio
+import typing
+from unittest.mock import patch
+
+import pytest
+
+import nanaimo
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.asyncio
+@patch('nanaimo.FixtureManager')
+async def test_observe_tasks(MockFixtureManager: typing.Any,
+                             event_loop: asyncio.AbstractEventLoop,
+                             dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
+    """
+    Test the observe_tasks method of Fixture
+    """
+
+    async def evaluating() -> int:
+        return 0
+
+    async def running() -> int:
+        waits = 2
+        while waits > 0:
+            await asyncio.sleep(.1)
+            waits -= 1
+        return 1
+
+    result = await dummy_nanaimo_fixture.observe_tasks_assert_not_done(evaluating(),
+                                                                       0,
+                                                                       running())
+    assert len(result) == 1
+    should_be_running = result.pop()
+
+    assert not should_be_running.done()
+
+    assert 1 == await should_be_running
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.asyncio
+@patch('nanaimo.FixtureManager')
+async def test_observe_tasks_failure(MockFixtureManager: typing.Any,
+                                     event_loop: asyncio.AbstractEventLoop,
+                                     dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
+    """
+    Test the observe_tasks method of Fixture where the running tasks exit.
+    """
+
+    async def evaluating() -> int:
+        waits = 2
+        while waits > 0:
+            await asyncio.sleep(.1)
+            waits -= 1
+        return 1
+
+    async def running() -> int:
+        return 1
+
+    with pytest.raises(nanaimo.AssertionError):
+        await dummy_nanaimo_fixture.observe_tasks_assert_not_done(evaluating(),
+                                                                  0,
+                                                                  running())
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.asyncio
+@patch('nanaimo.FixtureManager')
+async def test_observe_tasks_failure_no_assert(MockFixtureManager: typing.Any,
+                                               event_loop: asyncio.AbstractEventLoop,
+                                               dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
+    """
+    Test the observe_tasks method of Fixture where the running tasks exit but without throwing
+    an assertion error.
+    """
+
+    async def evaluating() -> int:
+        waits = 2
+        while waits > 0:
+            await asyncio.sleep(.1)
+            waits -= 1
+        return 1
+
+    async def running() -> int:
+        return 1
+
+    result = await dummy_nanaimo_fixture.observe_tasks(evaluating(),
+                                                       0,
+                                                       running())
+
+    assert 0 == len(result)
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.asyncio
+@patch('nanaimo.FixtureManager')
+async def test_observe_tasks_timeout(MockFixtureManager: typing.Any,
+                                     event_loop: asyncio.AbstractEventLoop,
+                                     dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
+    """
+    Test the observe_tasks method of Fixture where the running tasks do not exit.
+    """
+
+    async def evaluating() -> int:
+        while True:
+            await asyncio.sleep(1)
+
+    async def running() -> int:
+        while True:
+            await asyncio.sleep(1)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await dummy_nanaimo_fixture.observe_tasks_assert_not_done(evaluating(),
+                                                                  1,
+                                                                  running())
+
+
+@pytest.mark.timeout(20)
+@pytest.mark.asyncio
+@patch('nanaimo.FixtureManager')
+async def test_countdown_sleep(MockFixtureManager: typing.Any,
+                               event_loop: asyncio.AbstractEventLoop,
+                               dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
+    """
+    Test the observe_tasks method of Fixture where the running tasks do not exit.
+    """
+    await dummy_nanaimo_fixture.countdown_sleep(5.3)
+
+
+@pytest.mark.timeout(20)
+@pytest.mark.asyncio
+async def test_gather_timeout(gather_timeout_fixture: nanaimo.Fixture) -> None:
+    """
+    Test the standard fixture timeout.
+    """
+    gather_timeout_fixture.gather_timeout_seconds = 1.0
+    with pytest.raises(asyncio.TimeoutError):
+        await gather_timeout_fixture.gather()

--- a/test/test_nanaimo.py
+++ b/test/test_nanaimo.py
@@ -8,11 +8,11 @@ import asyncio
 import os
 import pathlib
 import typing
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
-import fixtures.simulators
+import fixtures
 import nanaimo
 import nanaimo.connections
 import nanaimo.connections.uart
@@ -21,11 +21,11 @@ import nanaimo.parsers.gtest
 
 
 @pytest.mark.timeout(10)
-def test_uart_monitor() -> None:
+def test_uart_monitor(serial_simulator_type: typing.Type) -> None:
     """
     Verify the nanaimo.ConcurrentUart class using a mock serial port.
     """
-    serial = fixtures.simulators.Serial(fixtures.FAKE_TEST_SUCCESS)
+    serial = serial_simulator_type(fixtures.FAKE_TEST_SUCCESS)
     last_line = fixtures.FAKE_TEST_SUCCESS[-1]
     with nanaimo.connections.uart.ConcurrentUart(serial) as monitor:
         while True:
@@ -53,10 +53,11 @@ async def test_program_uploader_failure(mock_JLinkExe: pathlib.Path,
 
 @pytest.mark.asyncio
 async def test_program_while_monitoring(mock_JLinkExe: pathlib.Path,
-                                        s32K144_jlink_scripts: typing.Iterator[pathlib.Path]) -> None:
+                                        s32K144_jlink_scripts: typing.Iterator[pathlib.Path],
+                                        serial_simulator_type: typing.Type) -> None:
     scripts = s32K144_jlink_scripts
     uploader = nanaimo.instruments.jlink.ProgramUploaderJLink(mock_JLinkExe)
-    serial = fixtures.simulators.Serial(fixtures.FAKE_TEST_SUCCESS)
+    serial = serial_simulator_type(fixtures.FAKE_TEST_SUCCESS)
     uploads = 0
     with nanaimo.connections.uart.ConcurrentUart(serial) as monitor:
         for script in scripts:
@@ -74,138 +75,17 @@ async def test_program_while_monitoring(mock_JLinkExe: pathlib.Path,
 
 
 @pytest.mark.asyncio
-async def test_failed_test() -> None:
-    serial = fixtures.simulators.Serial(fixtures.FAKE_TEST_FAILURE)
+async def test_failed_test(serial_simulator_type: typing.Type) -> None:
+    serial = serial_simulator_type(fixtures.FAKE_TEST_FAILURE)
     with nanaimo.connections.uart.ConcurrentUart(serial) as monitor:
         assert 1 == await nanaimo.parsers.gtest.Parser(10).read_test(monitor)
 
 
 @pytest.mark.asyncio
-async def test_timeout_while_monitoring() -> None:
-    serial = fixtures.simulators.Serial(['gibberish'], loop_fake_data=False)
+async def test_timeout_while_monitoring(serial_simulator_type: typing.Type) -> None:
+    serial = serial_simulator_type(['gibberish'], loop_fake_data=False)
     with nanaimo.connections.uart.ConcurrentUart(serial) as monitor:
         assert 0 != await nanaimo.parsers.gtest.Parser(4.0).read_test(monitor)
-
-
-@pytest.mark.timeout(10)
-@pytest.mark.asyncio
-@patch('nanaimo.FixtureManager')
-async def test_observe_tasks(MockFixtureManager: typing.Any,
-                             event_loop: asyncio.AbstractEventLoop,
-                             dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
-    """
-    Test the observe_tasks method of Fixture
-    """
-
-    async def evaluating() -> int:
-        return 0
-
-    async def running() -> int:
-        waits = 2
-        while waits > 0:
-            await asyncio.sleep(.1)
-            waits -= 1
-        return 1
-
-    result = await dummy_nanaimo_fixture.observe_tasks_assert_not_done(evaluating(),
-                                                                       0,
-                                                                       running())
-    assert len(result) == 1
-    should_be_running = result.pop()
-
-    assert not should_be_running.done()
-
-    assert 1 == await should_be_running
-
-
-@pytest.mark.timeout(10)
-@pytest.mark.asyncio
-@patch('nanaimo.FixtureManager')
-async def test_observe_tasks_failure(MockFixtureManager: typing.Any,
-                                     event_loop: asyncio.AbstractEventLoop,
-                                     dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
-    """
-    Test the observe_tasks method of Fixture where the running tasks exit.
-    """
-
-    async def evaluating() -> int:
-        waits = 2
-        while waits > 0:
-            await asyncio.sleep(.1)
-            waits -= 1
-        return 1
-
-    async def running() -> int:
-        return 1
-
-    with pytest.raises(nanaimo.AssertionError):
-        await dummy_nanaimo_fixture.observe_tasks_assert_not_done(evaluating(),
-                                                                  0,
-                                                                  running())
-
-
-@pytest.mark.timeout(10)
-@pytest.mark.asyncio
-@patch('nanaimo.FixtureManager')
-async def test_observe_tasks_failure_no_assert(MockFixtureManager: typing.Any,
-                                               event_loop: asyncio.AbstractEventLoop,
-                                               dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
-    """
-    Test the observe_tasks method of Fixture where the running tasks exit but without throwing
-    an assertion error.
-    """
-
-    async def evaluating() -> int:
-        waits = 2
-        while waits > 0:
-            await asyncio.sleep(.1)
-            waits -= 1
-        return 1
-
-    async def running() -> int:
-        return 1
-
-    result = await dummy_nanaimo_fixture.observe_tasks(evaluating(),
-                                                       0,
-                                                       running())
-
-    assert 0 == len(result)
-
-
-@pytest.mark.timeout(10)
-@pytest.mark.asyncio
-@patch('nanaimo.FixtureManager')
-async def test_observe_tasks_timeout(MockFixtureManager: typing.Any,
-                                     event_loop: asyncio.AbstractEventLoop,
-                                     dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
-    """
-    Test the observe_tasks method of Fixture where the running tasks do not exit.
-    """
-
-    async def evaluating() -> int:
-        while True:
-            await asyncio.sleep(1)
-
-    async def running() -> int:
-        while True:
-            await asyncio.sleep(1)
-
-    with pytest.raises(asyncio.TimeoutError):
-        await dummy_nanaimo_fixture.observe_tasks_assert_not_done(evaluating(),
-                                                                  1,
-                                                                  running())
-
-
-@pytest.mark.timeout(20)
-@pytest.mark.asyncio
-@patch('nanaimo.FixtureManager')
-async def test_countdown_sleep(MockFixtureManager: typing.Any,
-                               event_loop: asyncio.AbstractEventLoop,
-                               dummy_nanaimo_fixture: nanaimo.Fixture) -> None:
-    """
-    Test the observe_tasks method of Fixture where the running tasks do not exit.
-    """
-    await dummy_nanaimo_fixture.countdown_sleep(5.3)
 
 
 def test_enable_default_from_environ(nanaimo_defaults: nanaimo.config.ArgumentDefaults) -> None:

--- a/test/test_serial_log_watch.py
+++ b/test/test_serial_log_watch.py
@@ -1,0 +1,58 @@
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# This software is distributed under the terms of the MIT License.
+#
+
+import typing
+
+import pytest
+
+import nanaimo
+import nanaimo.connections
+import nanaimo.connections.uart
+import nanaimo.builtin
+import nanaimo.builtin.serial_log_watch
+
+
+@pytest.mark.asyncio
+async def test_default_match(serial_log_watch: nanaimo.builtin.serial_log_watch.Fixture,
+                             serial_simulator_type: typing.Type) -> None:
+    """
+    The default match matches everything in the first line.
+    """
+    simulated_serial = serial_simulator_type(['one', 'two'])
+
+    def uart_factory(*args: typing.Tuple) -> nanaimo.connections.uart.ConcurrentUart:
+        return nanaimo.connections.uart.ConcurrentUart(simulated_serial)
+    serial_log_watch._uart_factory = uart_factory
+    artifacts = await serial_log_watch.gather()
+    assert artifacts.matched_line == 'one'
+
+
+@pytest.mark.asyncio
+async def test_realistic_match(serial_log_watch: nanaimo.builtin.serial_log_watch.Fixture,
+                               serial_simulator_type: typing.Type) -> None:
+    """
+    Now test a more realistic matching scenario.
+    """
+    line_to_match = 'FOO LINUX Distribution 7.5'
+    simulated_serial = serial_simulator_type([
+        'UAVCAN is an open lightweight protocol designed for reliable',
+        'communication in aerospace and robotic applications',
+        'via robust vehicle bus networks.',
+
+        line_to_match,
+
+        'Features:',
+        '- Democratic network – no bus master, no single point of',
+        'failure.',
+        '- Publish/subscribe and request/response (RPC1)',
+        'exchange semantics.'
+    ])
+
+    def uart_factory(*args: typing.Tuple) -> nanaimo.connections.uart.ConcurrentUart:
+        return nanaimo.connections.uart.ConcurrentUart(simulated_serial)
+    serial_log_watch._uart_factory = uart_factory
+    artifacts = await serial_log_watch.gather(lw_pattern=r'LINUX\s+Distribution\s+(\d+\.\d+)')
+    assert artifacts.matched_line == line_to_match
+    assert artifacts.match.group(1) == '7.5'


### PR DESCRIPTION
Adding both a new builtin that will "grep" for a pattern on a uart and
adding a global "gather timeout" to the Fixture base.

This also includes more cleanup of the unit tests and improvments to the
documentation.