### PR TITLE
Fix #113: JLink script makes some args optional

### DIFF
--- a/src/nanaimo/instruments/jlink/__init__.py
+++ b/src/nanaimo/instruments/jlink/__init__.py
@@ -23,6 +23,7 @@ import typing
 
 import nanaimo
 import nanaimo.fixtures
+import functools
 
 
 class ProgramUploader(nanaimo.fixtures.SubprocessFixture):
@@ -104,7 +105,8 @@ class ProgramUploader(nanaimo.fixtures.SubprocessFixture):
         tmpfile = tempfile.NamedTemporaryFile(mode='w')
         setattr(inout_artifacts, 'tmpfile', tmpfile)
 
-        get_arg_func = self.get_arg_covariant_or_fail  # without a script, other args are required
+        # without a script, other args are required:
+        get_arg_func = functools.partial(self.get_arg_covariant_or_fail, arguments)
 
         if script_file_path is None:
             # keep around for as long as the command exists.
@@ -115,15 +117,15 @@ class ProgramUploader(nanaimo.fixtures.SubprocessFixture):
             setattr(inout_artifacts, 'scriptfile', script_file_path)
             with open(script_file_path, 'r') as user_script_file:
                 template = user_script_file.read()
-            get_arg_func = self.get_arg_covariant  # don't fail fixture on missing args
+            get_arg_func = functools.partial(self.get_arg_covariant, arguments)  # don't fail fixture on missing args
 
         # poor man's templating
         expanded_script_file = template.format(
-                hexfile=get_arg_func(arguments, 'hexfile'),
-                device=get_arg_func(arguments, 'device'),
-                speed=get_arg_func(arguments, 'interface-speed-khz'),
-                serial_interface=get_arg_func(arguments, 'serial-interface'),
-                reset_delay_millis=str(get_arg_func(arguments, 'reset-delay-millis'))
+                hexfile=get_arg_func('hexfile'),
+                device=get_arg_func('device'),
+                speed=get_arg_func('interface-speed-khz'),
+                serial_interface=get_arg_func('serial-interface'),
+                reset_delay_millis=str(get_arg_func('reset-delay-millis'))
             )
 
         with open(tmpfile.name, 'w') as tempfile_handle:

--- a/test/test_instrument_jlink.py
+++ b/test/test_instrument_jlink.py
@@ -30,6 +30,7 @@ async def test_jlink_upload(use_internal_template: bool,
 
     if not use_internal_template:
         test_args['jlink_up_script'] = str(test_jlink_template)
+        test_args['jlink_up_device'] = None  # fails unless args are optional with script
 
     artifacts = assert_success(await nanaimo_jlink_upload.gather(**test_args))
 
@@ -48,7 +49,7 @@ async def test_jlink_upload(use_internal_template: bool,
     hexfile_in_script = None  # type: typing.Optional[str]
     with open(scriptfile, 'r') as scriptfile_handle:
         for line in scriptfile_handle:
-            matchobj = re.search(r'^loadfile\s+((?:/|\w)+\.hex)$', line)
+            matchobj = re.search(r'^loadfile\s+((?:/|\w)+(?:/|[\w\. -])*\.hex)$', line)
             if matchobj:
                 hexfile_in_script = matchobj.group(1)
             print(line, end='')


### PR DESCRIPTION
This change allows template variables in a JLink script to be optional arguments to the ProgramUploader fixture when a script argument is also given.

It also adds a line to the test so that it would fail without this change (if you provided a script argument but not, for example, a `device` value.

It also makes the test's output regex a little more accepting of possible filepath contents, e.g. allowing dashes and periods after the initial path character.

Tests passed locally (macOS, python 3.7).